### PR TITLE
Fix invalid aspectRatio format

### DIFF
--- a/src/ExportedImage.tsx
+++ b/src/ExportedImage.tsx
@@ -177,7 +177,7 @@ export default function (props: ExportedImageProps) {
   const height = (isStaticImage && props.height) || (props.src as any).height;
 
   return isStaticImage ? (
-    <div style={isStaticImage ? { aspectRatio: width / height } : {}}>
+    <div style={isStaticImage ? { aspectRatio: (width / height).toString() } : {}}>
       <DynamicExportedImage {...props} />
     </div>
   ) : (


### PR DESCRIPTION
AspectRatio expects a number without "px" suffix as value. Transfering result of the calculation to String, ensures proper format is used.